### PR TITLE
[FIX] allow subscriptions and bundles as property productBundle

### DIFF
--- a/Classes/Domain/Model/Product.php
+++ b/Classes/Domain/Model/Product.php
@@ -112,9 +112,9 @@ class Product extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
 
 
     /**
-     * productBundle
+     * productBundle or productSubscription
      *
-     * @var \RKW\RkwShop\Domain\Model\ProductBundle
+     * @var \RKW\RkwShop\Domain\Model\Product
      */
     protected $productBundle;
 
@@ -394,9 +394,9 @@ class Product extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     }
 
     /**
-     * Returns the productBundle
+     * Returns the productBundle or productSubscription
      *
-     * @return \RKW\RkwShop\Domain\Model\ProductBundle $productBundle
+     * @return \RKW\RkwShop\Domain\Model\Product $productBundle
      */
     public function getProductBundle()
     {
@@ -404,12 +404,12 @@ class Product extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     }
 
     /**
-     * Sets the productBundle
+     * Sets the productBundle or productSubscription
      *
-     * @param \RKW\RkwShop\Domain\Model\ProductBundle $productBundle
+     * @param \RKW\RkwShop\Domain\Model\Product $productBundle
      * @return void
      */
-    public function setProductBundle(\RKW\RkwShop\Domain\Model\ProductBundle $productBundle): void
+    public function setProductBundle(\RKW\RkwShop\Domain\Model\Product $productBundle): void
     {
         $this->productBundle = $productBundle;
     }


### PR DESCRIPTION
It solves the problem that in case of a product assigned to a subscription no mail to assigned backend users has been sent. This happened due to the fact that the property Product->productBundle was determined to return an object of productBundle. Therefore an assigned productSubscription was returned as NULL.

Manual testing by ordering a publication did work well, functional testing requires migrating to the TYPO3 test framework and was omitted. But could you @skroggel tell, if there could be some negative side effects?